### PR TITLE
Upgrade to python 3; use emulator to display mock LED board on browser for easier debugging/ development

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,10 +7,12 @@ name = "pypi"
 munch = "*"
 pytz = "*"
 tzlocal = "*"
-feedparser = "<6.0.0"
+# feedparser = "<6.0.0"
 pyowm = "*"
+webcolors = "*"
+pycopy-colorsys = "*"
 
 [requires]
-python_version = "2.7"
+python_version = "3.8"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -4,13 +4,15 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+# setuptools = "<58.0"
 munch = "*"
 pytz = "*"
 tzlocal = "*"
 # feedparser = "<6.0.0"
 pyowm = "*"
 webcolors = "*"
-pycopy-colorsys = "*"
+urllib3 = "*"
+# pycopy-colorsys = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cecbd2d730d8d263c6ffae6532273b27f9374dabf75cc148d6c4da1ab1d341c9"
+            "sha256": "2ce9678f0f216ba2007fdc2a3d604f763df9de904b9adf307098b57ef58e0fca"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "2.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -16,20 +16,43 @@
         ]
     },
     "default": {
+        "backports.zoneinfo": {
+            "hashes": [
+                "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf",
+                "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328",
+                "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546",
+                "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6",
+                "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570",
+                "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9",
+                "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7",
+                "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987",
+                "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722",
+                "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582",
+                "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc",
+                "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b",
+                "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1",
+                "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08",
+                "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac",
+                "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '3.9'",
+            "version": "==0.2.1"
+        },
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
-            "version": "==2021.10.8"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.9.24"
         },
-        "chardet": {
+        "charset-normalizer": {
             "hashes": [
-                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
-                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version < '3'",
-            "version": "==4.0.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.1"
         },
         "feedparser": {
             "hashes": [
@@ -42,18 +65,18 @@
         },
         "geojson": {
             "hashes": [
-                "sha256:8831556d1ac18805c4955aa881e022e6ddcef44020b315200680eec6dd209e40",
-                "sha256:c8873d12421665f6731b8e4c3b2484a4516c0d9b286c26cb7cffa781d062301a"
+                "sha256:6e4bb7ace4226a45d9c8c8b1348b3fc43540658359f93c3f7e03efa9f15f658a",
+                "sha256:ccbd13368dd728f4e4f13ffe6aaf725b6e802c692ba0dde628be475040c534ba"
             ],
-            "version": "==2.3.0"
+            "version": "==2.5.0"
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version < '3'",
-            "version": "==2.10"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.4"
         },
         "munch": {
             "hashes": [
@@ -65,59 +88,81 @@
         },
         "pyowm": {
             "hashes": [
-                "sha256:1b42393ec661102f140755109a8cfc37142a5d9d3acbb8328041a8b7d730e1ce",
-                "sha256:39ee28a8f95fa9b028444e4ee8e2c3b20132bb2c1b8e15d5bf3d433161924d21",
-                "sha256:4263c355263a7e13525d6e5113f0f2d24808bb9a69a983d21b0729499f678116",
-                "sha256:4d50fd2afda80d283de30bd54a704fe3f4e7dd3db71f499adc751b6cc6bc1ce2",
-                "sha256:51a5a598fef4d327e5d08d48059f977337a3a2ad09d89ea9a1f4e87697280b77",
-                "sha256:630887c9189b58f5ecad6a571679d57defe48085faeea4d78825d7749bb61d10",
-                "sha256:acbbc0d68b6acefeedcd584c7921ec89de1edde5bf2144ddd019e37198ae4e1d",
-                "sha256:c015f896fdab1faa7c17032017a12e1bc77f085bb7d8a642a13717d394426513",
-                "sha256:e7983b013d9dfb4f93c3cbd167e6faa1503bef5a239218291da71dac37c23651",
-                "sha256:ed175873823a2fedb48e453505c974ca39f3f75006ef1af54fdbcf72e6796849"
+                "sha256:1a4dbca50c5856044de635df3c4f70c334bbba130ce8fb43eaf2892b1a4d7010",
+                "sha256:7ae83dad89998952b7244df89876732dc23c00e011defb9b64ec3e28c62ac76f",
+                "sha256:8196f77c91eac680676ed5ee484aae8a165408055e3e2b28025cbf60b8681e03",
+                "sha256:86463108e7613171531ba306040b43c972b3fc0b0acf73b12c50910cdd2107ab",
+                "sha256:c73dcf590ced0860e5b39fb43f56098329ef6b479526f91e558e677b1dd5cc37"
             ],
             "index": "pypi",
-            "version": "==2.9.0"
+            "version": "==3.3.0"
+        },
+        "pysocks": {
+            "hashes": [
+                "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299",
+                "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5",
+                "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"
+            ],
+            "version": "==1.7.1"
         },
         "pytz": {
             "hashes": [
-                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
-                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+                "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22",
+                "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"
             ],
             "index": "pypi",
-            "version": "==2021.3"
+            "version": "==2022.5"
         },
-        "requests": {
+        "pytz-deprecation-shim": {
             "hashes": [
-                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
-                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+                "sha256:8314c9692a636c8eb3bda879b9f119e350e93223ae83e70e80c31675a0fdc1a6",
+                "sha256:af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.27.1"
+            "version": "==0.1.0.post0"
+        },
+        "requests": {
+            "extras": [
+                "socks"
+            ],
+            "hashes": [
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==2.28.1"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:323161b22b7802fdc78f20ca5f6073639c64f1a7227c40cd3e19fd1d0ce6650a",
+                "sha256:e15b2b3005e2546108af42a0eb4ccab4d9e225e2dfbf4f77aad50c70a4b1f3ab"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.5"
         },
         "tzlocal": {
             "hashes": [
-                "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44",
-                "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"
+                "sha256:89885494684c929d9191c57aa27502afc87a579be5cdd3225c77c463ea043745",
+                "sha256:ee5842fa3a795f023514ac2d801c4a81d1743bbe642e3940143326b3a00addd7"
             ],
             "index": "pypi",
-            "version": "==2.1"
+            "version": "==4.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
-                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.12"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2ce9678f0f216ba2007fdc2a3d604f763df9de904b9adf307098b57ef58e0fca"
+            "sha256": "419aaa44df318f0634a61f2708609275b7e05debc3da0c4ac09a63eb728b970a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -35,33 +35,97 @@
                 "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac",
                 "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"
             ],
-            "markers": "python_version >= '3.6' and python_version < '3.9'",
+            "markers": "python_version < '3.9'",
             "version": "==0.2.1"
         },
         "certifi": {
             "hashes": [
-                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
-                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
+                "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+                "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.24"
+            "version": "==2023.7.22"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
-                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
+                "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96",
+                "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c",
+                "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710",
+                "sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706",
+                "sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020",
+                "sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252",
+                "sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad",
+                "sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329",
+                "sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a",
+                "sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f",
+                "sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6",
+                "sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4",
+                "sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a",
+                "sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46",
+                "sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2",
+                "sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23",
+                "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace",
+                "sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd",
+                "sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982",
+                "sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10",
+                "sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2",
+                "sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea",
+                "sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09",
+                "sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5",
+                "sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149",
+                "sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489",
+                "sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9",
+                "sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80",
+                "sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592",
+                "sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3",
+                "sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6",
+                "sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed",
+                "sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c",
+                "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200",
+                "sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a",
+                "sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e",
+                "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d",
+                "sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6",
+                "sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623",
+                "sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669",
+                "sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3",
+                "sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa",
+                "sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9",
+                "sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2",
+                "sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f",
+                "sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1",
+                "sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4",
+                "sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a",
+                "sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8",
+                "sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3",
+                "sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029",
+                "sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f",
+                "sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959",
+                "sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22",
+                "sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7",
+                "sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952",
+                "sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346",
+                "sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e",
+                "sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d",
+                "sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299",
+                "sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd",
+                "sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a",
+                "sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3",
+                "sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037",
+                "sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94",
+                "sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c",
+                "sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858",
+                "sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a",
+                "sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449",
+                "sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c",
+                "sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918",
+                "sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1",
+                "sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c",
+                "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac",
+                "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.1.1"
-        },
-        "feedparser": {
-            "hashes": [
-                "sha256:bd030652c2d08532c034c27fcd7c85868e7fa3cb2b17f230a44a6bbc92519bf9",
-                "sha256:cd2485472e41471632ed3029d44033ee420ad0b57111db95c240c9160a85831c",
-                "sha256:ce875495c90ebd74b179855449040003a1beb40cd13d5f037a0654251e260b02"
-            ],
-            "index": "pypi",
-            "version": "==5.2.1"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.2.0"
         },
         "geojson": {
             "hashes": [
@@ -80,11 +144,11 @@
         },
         "munch": {
             "hashes": [
-                "sha256:2d735f6f24d4dba3417fa448cae40c6e896ec1fdab6cdb5e6510999758a4dbd2",
-                "sha256:6f44af89a2ce4ed04ff8de41f70b226b984db10a91dcc7b9ac2efc1c77022fdd"
+                "sha256:542cb151461263216a4e37c3fd9afc425feeaf38aaa3025cd2a981fadb422235",
+                "sha256:71033c45db9fb677a0b7eb517a4ce70ae09258490e419b0e7f00d1e386ecb1b4"
             ],
             "index": "pypi",
-            "version": "==2.5.0"
+            "version": "==4.0.0"
         },
         "pyowm": {
             "hashes": [
@@ -103,66 +167,52 @@
                 "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5",
                 "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.7.1"
         },
         "pytz": {
             "hashes": [
-                "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22",
-                "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"
+                "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b",
+                "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"
             ],
             "index": "pypi",
-            "version": "==2022.5"
-        },
-        "pytz-deprecation-shim": {
-            "hashes": [
-                "sha256:8314c9692a636c8eb3bda879b9f119e350e93223ae83e70e80c31675a0fdc1a6",
-                "sha256:af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==0.1.0.post0"
+            "version": "==2023.3.post1"
         },
         "requests": {
             "extras": [
                 "socks"
             ],
             "hashes": [
-                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
-                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
+                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
-            "version": "==2.28.1"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
-        },
-        "tzdata": {
-            "hashes": [
-                "sha256:323161b22b7802fdc78f20ca5f6073639c64f1a7227c40cd3e19fd1d0ce6650a",
-                "sha256:e15b2b3005e2546108af42a0eb4ccab4d9e225e2dfbf4f77aad50c70a4b1f3ab"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2022.5"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.31.0"
         },
         "tzlocal": {
             "hashes": [
-                "sha256:89885494684c929d9191c57aa27502afc87a579be5cdd3225c77c463ea043745",
-                "sha256:ee5842fa3a795f023514ac2d801c4a81d1743bbe642e3940143326b3a00addd7"
+                "sha256:46eb99ad4bdb71f3f72b7d24f4267753e240944ecfc16f25d2719ba89827a803",
+                "sha256:f3596e180296aaf2dbd97d124fe76ae3a0e3d32b258447de7b939b3fd4be992f"
             ],
             "index": "pypi",
-            "version": "==4.2"
+            "version": "==5.0.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
-                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
+                "sha256:13abf37382ea2ce6fb744d4dad67838eec857c9f4f57009891805e0b5e123594",
+                "sha256:ef16afa8ba34a1f989db38e1dbbe0c302e4289a47856990d0682e374563ce35e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.12"
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.5"
+        },
+        "webcolors": {
+            "hashes": [
+                "sha256:29bc7e8752c0a1bd4a1f03c14d6e6a72e93d82193738fa860cbff59d0fcc11bf",
+                "sha256:c225b674c83fa923be93d235330ce0300373d02885cef23238813b0d5668304a"
+            ],
+            "index": "pypi",
+            "version": "==1.13"
         }
     },
     "develop": {}

--- a/main.py
+++ b/main.py
@@ -1,9 +1,7 @@
 from datetime import datetime, timedelta
 from src.data.scoreboard_config import ScoreboardConfig
 from src.renderers.main import MainRenderer
-# from renderers.offday import OffdayRenderer
-# from renderers.standings import StandingsRenderer
-from rgbmatrix import RGBMatrix, RGBMatrixOptions
+from src.infra.rgb_matrix_wrapper import RGBMatrix, RGBMatrixOptions
 from src.utils import args, led_matrix_options
 from src.data.data import Data
 # import renderers.standings

--- a/src/api/cfb.py
+++ b/src/api/cfb.py
@@ -1,9 +1,9 @@
 # import urllib.request
 import urllib3.request
 import json
-from scrape_util import api_to_json
+from src.api.scrape_util import api_to_json
 import munch
-from color_convert import adjust_colors
+from src.api.color_convert import adjust_colors
 
 nfl_flg = 0
 NFL_URL = 'http://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard'
@@ -53,7 +53,7 @@ class FootballAPIWrapper:
       match_info['time'] = event['status']['displayClock']
       try:
           match_info['broadcast'] = ",".join(event['competitions'][0]['broadcasts'][0]['names'])
-      except IndexError, KeyError:
+      except ( IndexError, KeyError ):
           match_info['broadcast'] = 'N/A'
       match_info['period'] = event['status']['period']
 

--- a/src/api/cfb.py
+++ b/src/api/cfb.py
@@ -1,5 +1,3 @@
-# import urllib.request
-import urllib3.request
 import json
 from src.api.scrape_util import api_to_json
 import munch

--- a/src/api/cfb_util.py
+++ b/src/api/cfb_util.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     url = 'http://site.api.espn.com/apis/site/v2/sports/football/college-football/scoreboard'
     master_list = generate_match_list(url)
     # print(master_list[0])
-    print(master_list)
+    # print(master_list)
 
 
 

--- a/src/api/scrape_util.py
+++ b/src/api/scrape_util.py
@@ -2,11 +2,14 @@
 # fetch data from api
 # save relevant data into variables
 
-import urllib
+import urllib.request
 # import urllib3.request
 import json
 
-def api_to_json(url):
-    response = urllib.urlopen(url).read()
+def api_to_json(url_str):
+    # response = urllib.urlopen(url).read()
     # response = urllib3.request.urlopen(url).read()
-    return json.loads(response)
+    with urllib.request.urlopen(url_str) as url:
+        response = url.read()
+        # I'm guessing this would output the html source code ?
+        return json.loads(response)

--- a/src/data/color.py
+++ b/src/data/color.py
@@ -1,5 +1,5 @@
 from utils import get_file
-from rgbmatrix import graphics
+from src.infra.rgb_matrix_wrapper import graphics
 import json
 import debug
 import os.path

--- a/src/data/data.py
+++ b/src/data/data.py
@@ -37,7 +37,7 @@ class Data:
     games = self.cfb.day()
     if self.config.is_my_team_mode:
       # using lambda because making it a function would've been painful with getting team names and preferred teams and such
-      print(games[0].home.team_name)
+      # print(games[0].home.team_name)
       filtered_games = filter(lambda x: x.home.team_location in self.config.preferred_teams or x.away.team_location in self.config.preferred_teams, games)
       games = list(filtered_games)
     if self.config.is_good_games_only_mode:

--- a/src/data/layout.py
+++ b/src/data/layout.py
@@ -1,4 +1,4 @@
-from rgbmatrix import graphics
+from src.infra.rgb_matrix_wrapper import graphics
 from src.utils import get_file
 import json
 import debug

--- a/src/data/scoreboard_config.py
+++ b/src/data/scoreboard_config.py
@@ -1,6 +1,6 @@
 from src.utils import get_file, deep_update
-from layout import Layout
-from color import Color
+from src.data.layout import Layout
+from src.data.color import Color
 import json
 import os
 import sys

--- a/src/infra/rgb_matrix_wrapper.py
+++ b/src/infra/rgb_matrix_wrapper.py
@@ -1,0 +1,21 @@
+import os
+if os.getenv('LED_ENV') == 'production':
+    from rgbmatrix import RGBMatrix, RGBMatrixOptions, graphics
+else:
+    from RGBMatrixEmulator import RGBMatrix, RGBMatrixOptions, graphics
+
+# class RGBMatrixWrapper:
+#   # def __init__(self):
+#   #   self.json = layout_json
+
+#   @classmethod
+#   def RGBMatrix(cls):
+#     return RGBMatrix
+
+#   @classmethod
+#   def RGBMatrixOptions(cls):
+#     return RGBMatrixOptions
+
+#   @classmethod
+#   def graphics(cls):
+#     return graphics

--- a/src/renderers/finalinfo.py
+++ b/src/renderers/finalinfo.py
@@ -1,4 +1,4 @@
-from rgbmatrix import graphics
+from src.infra.rgb_matrix_wrapper import graphics
 
 class FinalInfoRenderer:
   def __init__(self, canvas, data):

--- a/src/renderers/game_situation.py
+++ b/src/renderers/game_situation.py
@@ -1,4 +1,4 @@
-from rgbmatrix import graphics
+from src.infra.rgb_matrix_wrapper import graphics
 from src.renderers.renderer_utils import RendererUtils
 import math
 import random

--- a/src/renderers/pregameinfo.py
+++ b/src/renderers/pregameinfo.py
@@ -1,5 +1,5 @@
 from time import time
-from rgbmatrix import graphics
+from src.infra.rgb_matrix_wrapper import graphics
 from datetime import datetime, timedelta
 
 class PregameInfoRenderer:

--- a/src/renderers/renderer_utils.py
+++ b/src/renderers/renderer_utils.py
@@ -1,4 +1,4 @@
-from rgbmatrix import graphics
+from src.infra.rgb_matrix_wrapper import graphics
 
 class RendererUtils:
   def convert_hex_to_color_graphic(self, hex_str):

--- a/src/renderers/teams.py
+++ b/src/renderers/teams.py
@@ -84,6 +84,7 @@ class TeamsRenderer:
     ranking = str(team.team_ranking)
 
     # graphics.DrawText(self.canvas, font["font"], x, y, text_color_graphic, ranking)
+    # print(f"ranking: {ranking}")
     graphics.DrawText(self.canvas, font["font"], ranking_x, ranking_y, text_color_graphic, ranking)
 
   def __render_team_text(self, team, homeaway, color, x, y):
@@ -110,7 +111,7 @@ class TeamsRenderer:
 
   def __render_possession(self):
     # find out who has possession
-    print(self.game)
+    # print(self.game)
     homeaway = self.game.possession_home_or_away
     if homeaway == '': return
     coords = self.data.config.layout.coords("teams.possession.{}".format(homeaway))

--- a/src/renderers/teams.py
+++ b/src/renderers/teams.py
@@ -1,4 +1,4 @@
-from rgbmatrix import graphics
+from src.infra.rgb_matrix_wrapper import graphics
 from src.renderers.renderer_utils import RendererUtils
 
 class TeamsRenderer:

--- a/src/renderers/timekeeper.py
+++ b/src/renderers/timekeeper.py
@@ -1,4 +1,4 @@
-from rgbmatrix import graphics
+from src.infra.rgb_matrix_wrapper import graphics
 from src.renderers.renderer_utils import RendererUtils
 
 # TODO: set as constant read from config files

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,4 @@
-from rgbmatrix import RGBMatrixOptions, graphics
+from src.infra.rgb_matrix_wrapper import RGBMatrixOptions, graphics
 import collections
 import argparse
 import os

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-from rgbmatrix import RGBMatrixOptions, graphics
+from src.infra.rgb_matrix_wrapper import RGBMatrixOptions, graphics
 import collections
 import argparse
 import os


### PR DESCRIPTION
When the script is run, it will now display the scoreboard via the emulator by default. (Accessible via `http://localhost:8888`)